### PR TITLE
Change order of /system mount options

### DIFF
--- a/system/bin/AKT
+++ b/system/bin/AKT
@@ -45,8 +45,8 @@ read option
 echo ""
 case $option in
 1 ) #Project_Zhana_Battery
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PZ_battery > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -68,8 +68,8 @@ sleep 10
 sleep 5; main_menu_op3;
 exit;;
 2 ) #Nameless_Battery 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" ./system/etc/AKT/NLB_battery > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -90,8 +90,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 3 ) #FairPark
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FairPark > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -112,8 +112,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 4 ) #Fusion Conservative
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionC > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -134,8 +134,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 5 ) #Project_XANA_Battery
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PX_battery > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -156,8 +156,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 6 ) #Project_XANA_Extreme
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PX_battery_extreme > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -215,8 +215,8 @@ read option
 echo ""
 case $option in
 1 ) #Project_Zhana_Battery
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PZ_batteryT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -238,8 +238,8 @@ sleep 10
 sleep 5; main_menu_op3;
 exit;;
 2 ) #Nameless_Battery 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/NLB_batteryT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -260,8 +260,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 3 ) #FairPark
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FairParkT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -282,8 +282,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 4 ) #Fusion Conservative
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionCT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -304,8 +304,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 5 ) #Project_XANA_Battery
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PX_batteryT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -326,8 +326,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 6 ) #Project_XANA_Extreme
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PX_battery_extremeT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -383,8 +383,8 @@ read option
 echo ""
 case $option in
 1 ) #Burnout PR3 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/BEF > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/etc/init.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -405,8 +405,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 2 ) #Burnout PR3.5 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/BPN > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/etc/init.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -426,8 +426,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 3 )  #Nameless Performance
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/NLB_performance > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -448,8 +448,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 4 ) #Fusion Perfomance
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionP > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -503,8 +503,8 @@ read option
 echo ""
 case $option in
 1 ) #Burnout PR3 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/BEFT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -525,8 +525,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 #2 ) #Burnout PR3.5 
-#$BB mount -o remount,rw /system 2>/dev/null
-#mount -o remount,rw /system 2>/dev/null
+#$BB mount -o rw,system /system 2>/dev/null
+#mount -o rw,system /system 2>/dev/null
 #if [ -e "/system/su.d/99AKT" ]; then
 #cat /system/etc/AKT/BPN > /system/su.d/99AKT
 #chmod 700 /system/su.d/99AKT
@@ -543,8 +543,8 @@ exit;;
 #sleep 5; main_menu_op3t;
 #exit;;
 2 )  #Nameless Performance
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/NLB_performanceT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -565,8 +565,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 3 ) #Fusion Perfomance
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionPT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -624,8 +624,8 @@ read option
 echo ""
 case $option in
 1 ) #FusionR
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionR > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -646,8 +646,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 2 ) #GhostPepper
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/GhostPepper > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -668,8 +668,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 3 ) #Fusion Balanced
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionB > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -690,8 +690,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 4 ) #Nameless Balanced 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/NLB_balanced > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -712,8 +712,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 5 ) #HawkPepper 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/HawkPepper > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -734,8 +734,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 6 ) #Project Zhana Balanced
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PZ_balanced > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -756,8 +756,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 7 ) #Project XANA Balanced
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PX_balanced > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -815,8 +815,8 @@ read option
 echo ""
 case $option in
 1 ) #FusionR
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionR > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -837,8 +837,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 2 ) #GhostPepper
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/GhostPepperT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -859,8 +859,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 3 ) #Fusion Balanced
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/FusionBT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -881,8 +881,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 4 ) #Nameless Balanced 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/NLB_balancedT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -903,8 +903,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 5 ) #HawkPepper 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/HawkPepperT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -925,8 +925,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 6 ) #Project Zhana Balanced
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PZ_balancedT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -947,8 +947,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3t;
 exit;;
 7 ) #Project XANA Balanced
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PX_balancedT > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -1000,8 +1000,8 @@ read option
 echo ""
 case $option in
 1 ) #Burnout EAS
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/BEF > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -1022,8 +1022,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 2 ) #Burnout PR3.5 
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/PZ_battery > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -1059,8 +1059,8 @@ echo " For additional information and questions, please visit our XDA thread"
 sleep 5; main_menu_op3;
 exit;;
 3 )  #Nameless Performance
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 if [ -e "/system/su.d/99AKT" ]; then
 grep -v "sleep" /system/etc/AKT/NLB_performance > /system/etc/AKT/Temp && mv /system/etc/AKT/Temp /system/su.d/99AKT
 chmod 700 /system/su.d/99AKT
@@ -1115,8 +1115,8 @@ exit
 function Disable
 {
 echo ""
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 cat /system/etc/AKT/DisableInitd > /system/etc/init.d/99AKT
 cat /system/etc/AKT/DisableInitd > /system/su.d/99AKT
 cat /system/etc/AKT/DisableInitd > /storage/emulated/0/AKT
@@ -1240,8 +1240,8 @@ done
  function other
 {
 echo ""
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 echo -e "\e[01;31m We don't support any other device. \e[00;37m"
 sleep 2
 echo -e "\e[01;31m If you still want to use the tweaks select from above the device most similar to your device. \e[00;37m"
@@ -1258,8 +1258,8 @@ exit;
  function reapply
 {
 echo ""
-$BB mount -o remount,rw /system 2>/dev/null
-mount -o remount,rw /system 2>/dev/null
+$BB mount -o rw,system /system 2>/dev/null
+mount -o rw,system /system 2>/dev/null
 clear
 if [ -e "/system/su.d/99AKT" ]; then
 chmod 700 /system/su.d/99AKT


### PR DESCRIPTION
This one I'm not sure of. I only own Mi6 and on MIUI I'm getting `Device or resource busy` with the original mount options. Didn't know it would but somehow the order seems to matter. If it doesn't apply to OP phones feel free to reject the PR.